### PR TITLE
Remove typesVersions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,13 +37,6 @@
       "require": "./dist/index.js"
     }
   },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/*"
-      ]
-    }
-  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
I used this plugin in a `vite.config.ts` (not `.js`) and typescript wouldn't stop complaining about missing types. It seems the `typesVersions` tag only works when actually specifying a version. But since this is for every version, you can remove the tag entirely yielding the same definition, resolving the bug in the process.