### PR TITLE
feat: add config for multi preload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ import {preload} from 'unplugin-auto-expose';
 
 export default defineConfig({
   plugins: [
-    preload.vite()
+    preload.vite({
+      exposeName: (name) => name, // must be same as config in renderer config
+      noContextBridgeEntries: [], // fill filename without .ts here if you must set contextIsolation to false for some window, eg ['preload2']
+    })
   ]
 })
 ```
@@ -53,7 +56,11 @@ import {renderer} from 'unplugin-auto-expose';
 export default defineConfig({
   plugins: [
     renderer.vite({
-      preloadEntry: '/absolute/path/to/preload.ts'
+      exposeName: (name) => name, // must be same as config in preload config
+      virtualModuleMap: {
+        '#preload1': '/absolute/path/to/preload1.ts',
+        '#preload2': '/absolute/path/to/preload2.ts',
+      }
     })
   ]
 })
@@ -66,9 +73,12 @@ To configure the TypeScript, add a path to your renderer.
 {
   "compilerOptions": {
     "paths": {
-      "#preload": [
-        "/path/to/preload"
-      ]
+      "#preload1": [
+        "/path/to/preload1"
+      ],
+      "#preload2": [
+        "/path/to/preload2"
+      ],
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,14 @@
-export interface PreloadOptions {}
+export interface CommonOptions {
+  exposeName?: (name: string) => string;
+}
 
-export interface RendererOptions {
-  preloadEntry: string;
+export interface PreloadOptions extends CommonOptions {
+  noContextBridgeEntries?: string[];
+}
+
+export interface RendererOptions extends CommonOptions {
+  preloadEntry?: string;
+  virtualModuleMap?: Record<string, string>; // virtual module name to preloadEntry path
 }
 
 export interface ExportInfo {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,10 @@
+import { CommonOptions } from './types';
+
+export const generateExposedName = (
+  originName: string,
+  options: CommonOptions | undefined,
+) => {
+  return options && options.exposeName
+    ? options.exposeName(originName)
+    : `__electron_preload__${originName}`;
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { CommonOptions } from './types';
+import type { CommonOptions } from './types';
 
 export const generateExposedName = (
   originName: string,


### PR DESCRIPTION
thanks for your awesome work on this plugin that makes renderer code using preload api easier (the traditional way of writing  contextBridge.exposeInMainWorld and adding ts type by hand to Window is really unpleasant)

in our use case, there are some different preload entries for different renderer window, and for some window, we must turn off contextIsolation which makes contextBridge.exposeInMainWorld unavailable. Also in some cases the exposed api is meant to be used by third party developers, so we'd rather the variable name to be just like 'nodeVersions' than '__electron_preload__nodeVersions'

so I added some config options to extend the functionality

1. add virtualModuleMap config for multi preload support
2. add exposeName config option for custom variable name exposes
3. add noContextBridgeEntries config option for contextIsolation option