### PR TITLE
Correct import @babel/traverse

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -19,7 +19,7 @@ import {
 } from "@babel/types";
 
 import traverseModule from "@babel/traverse";
-const traverse = traverseModule.default
+const traverse = typeof(traverseModule) == 'function' ? traverseModule : traverseModule.default
 
 export const preload = createUnplugin(
     () => {


### PR DESCRIPTION
Why this change is required?

Compiled version of the library `@babel/traverse` adds `__esModule` property to `exports`. Despite the fact that it is CommonJS module. They just do this:
```
Object.defineProperty(exports, "__esModule", {
  value: true
});
```
(it is in @babel/traverse:/lib/index.js, you can quickly see it here: https://unpkg.com/@babel/traverse@7.23.7/lib/index.js)

In ESM-version of your plugin:
```
import traverseModule from "@babel/traverse";
var traverse = traverseModule.default;
```
(https://unpkg.com/unplugin-auto-expose@0.3.0/dist/index.js)

When we run ESM-version of your plugin with Node.js then it works fine.
`import` from CommonJS module gives us just `exports` object, so we should take `.default` from it.

But in CJS-version of your plugin:
```
var _traverse = require('@babel/traverse'); var _traverse2 = _interopRequireDefault(_traverse);
var traverse = _traverse2.default.default;
```
and
```
function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
```
(https://unpkg.com/unplugin-auto-expose@0.3.0/dist/index.cjs)
So `traverse` = `undefined` because following happens:
- `_traverse` = `exports` object from `@babel/traverse`
- there is `__esModule` property in `_traverse`
- after `_interopRequireDefault` `_traverse2` is just equal to `_traverse`
- so `traverse` function is in `_traverse2.default`
- and `_traverse2.default.default` = `undefined`


Also this problem happens when we run ESM-version of your plugin with Bun (https://bun.sh/).
Bun supports ESM but when you `import` CommonJS module and there is `exports.__esModule` then Bun returns `exports.default` instead of `exports`.
So in Bun we should run:
```
import traverseModule from "@babel/traverse";
var traverse = traverseModule;
```


Basically it looks like a bug in `@babel/traverse`, they should not add `__esModule` to `exports` of CommonJS module.

But in any case I believe that when you deal with CJS from ESM it is more correctly to check if you need to use `.default` or not.
